### PR TITLE
fix: Correct documentation file paths in csproj

### DIFF
--- a/FeedReader/FeedReader.csproj
+++ b/FeedReader/FeedReader.csproj
@@ -32,8 +32,8 @@
     <NoWarn></NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\net6.0\CodeHollow.FeedReader.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
+    <DocumentationFile>bin\Debug\net8.0\CodeHollow.FeedReader.xml</DocumentationFile>
     <NoWarn></NoWarn>
   </PropertyGroup>
 
@@ -41,8 +41,8 @@
     <DocumentationFile>bin\Release\netstandard2.0\CodeHollow.FeedReader.xml</DocumentationFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
-    <DocumentationFile>bin\Release\net6.0\CodeHollow.FeedReader.xml</DocumentationFile>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+    <DocumentationFile>bin\Release\net8.0\CodeHollow.FeedReader.xml</DocumentationFile>
     <NoWarn></NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
This commit corrects the PropertyGroup conditions for generating documentation files to reference net8.0 instead of net6.0, aligning with the project's target frameworks.

#3 